### PR TITLE
[#32] feat: add toggle to kanban and lists view

### DIFF
--- a/app/views/todo_lists/index.html.erb
+++ b/app/views/todo_lists/index.html.erb
@@ -1,10 +1,12 @@
-<div class="container mt-4 pb-5 responsive-width">
+<div class="container mt-4 pb-5">
   <div class="row">
     <div class="col-12">
       <!-- Header da listagem -->
       <div class="d-flex justify-content-between align-items-center mb-4">
         <h1 class="h2 mb-0">Listas</h1>
-        <%= link_to 'Nova Lista', new_todo_list_path, class: "btn btn-primary" %>
+        <% if @todo_lists.any? %>
+          <%= link_to 'Nova Lista', new_todo_list_path, class: "btn btn-primary" %>
+        <% end %>
       </div>
       <!-- Listagem -->
       <% if @todo_lists.any? %>

--- a/app/views/todo_lists/show.html.erb
+++ b/app/views/todo_lists/show.html.erb
@@ -4,11 +4,24 @@
       <h1 class="display-4 text-primary mb-0"><%= @todo_list.title %></h1>
       <div class="mt-3">
         <%= link_to 'Home', todo_lists_path, class: "btn btn-outline-secondary" %>
+        <div class="btn-group" role="group" aria-label="View toggle button group">
+          <input type="radio" class="btn-check" name="view_toggle" id="btnradio_list" autocomplete="off"
+            <%= params[:view] != "kanban" ? "checked" : "" %>
+            onchange="window.location.href='?view=list'">
+          <label class="btn btn-outline-primary" for="btnradio_list">Lista</label>
+          <input type="radio" class="btn-check" name="view_toggle" id="btnradio_kanban" autocomplete="off"
+            <%= params[:view] == "kanban" ? "checked" : "" %>
+            onchange="window.location.href='?view=kanban'">
+          <label class="btn btn-outline-primary" for="btnradio_kanban">Kanban</label>
+        </div>
       </div>
     </div>
   </div>
-  <!-- Lista -->
-  <%= render partial: "shared/tasks_list", locals: { todo_list: @todo_list, items: @items } %>
-  <!-- Kanban -->
-  <%= render 'shared/kanban', todo_list: @todo_list, items: @items %>
+  <% if params[:view] == "kanban" %>
+    <!-- Kanban -->
+    <%= render 'shared/kanban', todo_list: @todo_list, items: @items %>
+  <% else %>
+    <!-- Lista -->
+    <%= render partial: "shared/tasks_list", locals: { todo_list: @todo_list, items: @items } %>
+  <% end %>
 </div>


### PR DESCRIPTION
## Descrição
Esta Pull Request contém a implementação da feature do botão que altera entre a visualização modo lista para o modo kanban. A lógica foi construída utilizando a query param `view` na URL da página de visualização.

## Alterações realizadas
- Implementação da lógica para a mudança do modo de visualização em lista/kanban.

## Issues relacionadas
- Closes #32

## Revisores
@RicardoCamposJr

## Capturas de tela
### Toggle de mudança de visualização (modo lista):
![image](https://github.com/user-attachments/assets/184190e2-a112-4df3-92dd-25799c219c87)

### Toggle de mudança de visualização (modo kanban):
![image](https://github.com/user-attachments/assets/dc20aaf2-a48f-4cb3-8d48-834706fdf2ee)

## Observações adicionais
- Posteriormente, para uma melhor experiência do usuário, seria interessante armazenar a escolha de visualização do usuário em localstorage para manter o modo de visualização dele automaticamente.