### PR TITLE
[#49] feat: add mailing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,10 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+
+  gem "letter_opener"
+
+  gem "letter_opener_web"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -158,6 +160,17 @@ GEM
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.1)
@@ -407,6 +420,8 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  letter_opener
+  letter_opener_web
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,33 @@
-<h2>Change your password</h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
-
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+<div class="row justify-content-center">
+  <div class="col-md-6 col-lg-4 my-auto">
+    <div class="card">
+      <div class="card-header text-center text-light card-header-gradient">
+        <h2>Altere a sua senha</h2>
+      </div>
+      <div class="card-body">
+        <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+          <%= render "devise/shared/error_messages", resource: resource %>
+          <%= f.hidden_field :reset_password_token %>
+          <div class="mb-3">
+            <%= f.label :password, "Nova senha", class: "form-label" %>
+            <% if @minimum_password_length %>
+              <br>
+              <small class="text-muted">(Mínimo de <%= @minimum_password_length %> caracteres)</small>
+            <% end %>
+            <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "form-control" %>
+          </div>
+          <div class="mb-3">
+            <%= f.label :password_confirmation, "Confirme a nova senha", class: "form-label" %>
+            <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
+          </div>
+          <div class="d-grid">
+            <%= f.submit "Alterar minha senha", class: "btn btn-primary" %>
+          </div>
+        <% end %>
+        <div class="text-center mt-3">
+          <%= render "devise/shared/links" %>
+        </div>
+      </div>
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,6 +38,8 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # Set localhost to be used by links generated in mailer templates.
+  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.perform_deliveries = true
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
   # Print deprecation notices to the Rails logger.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,16 +57,19 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_url_options = { host: "www.futurodominio.com", protocol: "https" }
+  config.action_mailer.delivery_method = :smtp
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
-  # config.action_mailer.smtp_settings = {
-  #   user_name: Rails.application.credentials.dig(:smtp, :user_name),
-  #   password: Rails.application.credentials.dig(:smtp, :password),
-  #   address: "smtp.example.com",
-  #   port: 587,
-  #   authentication: :plain
-  # }
+  config.action_mailer.smtp_settings = {
+    address:              "smtp.gmail.com",
+    port:                 587,
+    domain:               ENV["SMTP_DOMAIN"],
+    user_name:            ENV["SMTP_USERNAME"],
+    password:             ENV["SMTP_PASSWORD"],
+    authentication:       "plain",
+    enable_starttls_auto: true
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,17 +1,10 @@
 Rails.application.routes.draw do
   devise_for :users
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
-  # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
-  # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-  # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-
-  # Defines the root path route ("/")
-  # root "posts#index"
   root to: "welcome_page#index"
 
   # Proteger as rotas da aplicação com autenticação
@@ -23,5 +16,10 @@ Rails.application.routes.draw do
         end
       end
     end
+  end
+
+  # Letter Opener Web para visualizar e-mails em desenvolvimento
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end
 end


### PR DESCRIPTION
## Descrição
Esta Pull Request contém a implementação do serviço de recuperação de senha por email. Foi implementada a lógica para testes em ambiente de desenvolvimento, assim como, o esqueleto para posterior configuração em produção.

## Alterações realizadas
- Implementação da lógica referente à recuperação de senha.
- Inclusão da gem `letter_opener_web` para visualização do email de recuperação, no ambiente de desenvolvimento.
- Estilização do formulário de recuperação de senha.
- Tradução do formulário de recuperação de senha.
- Configuração do serviço de email `Google SMTP` utilizando envs.

## Issues relacionadas
- Closes #49

## Revisores
@RicardoCamposJr

## Capturas de tela
### Visualização de emails de recuperação de senha pelo `letter_opener_web`.
![image](https://github.com/user-attachments/assets/d8068cff-a221-44a5-b4e8-7d877eda4a3b)

### Formulário de recuperação de senha:
![image](https://github.com/user-attachments/assets/6399366d-f602-478a-9b2d-8af9b1bf2960)

## Observações adicionais
- Após o deploy, será necessário a mudança das credenciais do serviço de email.