### PR TITLE
fix: adjust host in default_url_options to mailer

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,7 +57,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "www.futurodominio.com", protocol: "https" }
+  config.action_mailer.default_url_options = { host: "todo-v360.onrender.com", protocol: "https" }
   config.action_mailer.delivery_method = :smtp
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.


### PR DESCRIPTION
## Descrição
Essa PR tem a finalidade de integrar as alterações presentes na branch `development` à branch `main`. Essas alterações são para permitir o envio correto dos emails na recuperação de senhas. 

## Alterações realizadas
- Alteração no campo `host` presente na configuração `config.action_mailer.default_url_options`.
